### PR TITLE
Added missing comma to bot initialization, was causing "dice_maiden_l…

### DIFF
--- a/dice_maiden_lite.rb
+++ b/dice_maiden_lite.rb
@@ -314,7 +314,7 @@ end
 
 Dotenv.load
 # Add API token
-@bot = Discordrb::Bot.new token: ENV['TOKEN'] compress_mode: :large, ignore_bots: true, fancy_log: true
+@bot = Discordrb::Bot.new token: ENV['TOKEN'], compress_mode: :large, ignore_bots: true, fancy_log: true
 @bot.gateway.check_heartbeat_acks = false
 
 # Check for command


### PR DESCRIPTION
Running `ruby -c dice_maiden_lite.rb` would lead to the following error:

```
dice_maiden_lite.rb:317: syntax error, unexpected tIDENTIFIER, expecting end-of-input
...ken: ENV['TOKEN'] compress_mode: :large, ignore_bots: true, ...
```

This resulted from a missing comma between `token: ENV['TOKEN']` and `compress_mode: :large`. Adding it solved the compilation error, and I've tested the lite bot in a private server since then.