### PR TITLE
Add an alias for the AGE system of games

### DIFF
--- a/dice_maiden.rb
+++ b/dice_maiden.rb
@@ -18,6 +18,7 @@ def alias_input_pass(input)
       [/\b\d+dF\b/i, "Fudge", /\b(\d+)dF\b/i, "\\1d3 f1 t3"], # Fate fudge dice
       [/\b\d+wh\d+\+/i, "Warhammer", /\b(\d+)wh(\d+)\+/i, "\\1d6 t\\2"], # Warhammer (AoS/40k)
       [/\bdd\d\d\b/i, "Double Digit", /\bdd(\d)(\d)\b/i, "(1d\\1 * 10) + 1d\\2"], # Rolling one dice for each digit
+      [/\bage\b/i, "AGE System Test", /\b(age)\b/i, "2d6 + 1d6"], # 2d6 plus one drama/dragon/stunt die
   ]
 
   @alias_types = []


### PR DESCRIPTION
The [AGE system](https://greenroninstore.com/collections/age-system) games use 3d6 for ability tests, with 1 of the dice typically being represented with a different color, size, markings, etc. This different die is referred to as the drama die, stunt die, or dragon die depending on the game, but it functions the same across all of them. For the AGE system it's important that all 3 dice be rolled together but that the result of the drama die can be distinguished from the others. This can be done in Dice Maiden with `!roll 2d6 + 1d6`, but since _every single test_ is always made this way it would be helpful to have an alias for it so players don't have to continuously type or copy/paste the sequence. Games in the AGE system include Fantasy Age, Dragon Age, Modern Age, Blue Rose, and The Expanse RPG.