### PR TITLE
Add the server option to show roll requests in results

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ The following examples outline how to change, reset, or check the prefix used by
 
 `!dm prefix check` : Checks the bots current prefix
 
+## Set Bot Request Display
+
+You can set the bot to display the actual roll executed as part of the bot response with this server-wide option. This is off by default.
+
+`!dm request show` : Show the roll requests in the output.
+
+`!dm request hide` : Hide the roll requests in the output.
+
 # Game Systems Specific Rolls
 Warhammer 40k Wrath and Glory example syntaxes:
 

--- a/dice_maiden.rb
+++ b/dice_maiden.rb
@@ -19,6 +19,7 @@ Dotenv.load
 @logging = ARGV[1].to_i
 @prefix = ''
 @check = ''
+@request_option = false
 
 # open connection to sqlite db and set timeout to 10s if the database is busy
 $db = SQLite3::Database.new "main.db"
@@ -31,8 +32,12 @@ mutex = Mutex.new
   mutex.lock
 
   begin
-    # handle !dm prefix command
-    next if handle_prefix(event) == true
+    # handle !dm <command>
+    next if check_server_options(event) == true
+
+    #check the sever request options
+    check_request_option(event)
+
     # check what prefix the server should be using
     check_prefix(event)
     # check if input is even valid
@@ -118,7 +123,7 @@ mutex = Mutex.new
       if @logging == "debug"
         log_roll(event)
       end
-      
+
       # Print dice result to Discord channel
       @has_comment = !@comment.to_s.empty? && !@comment.to_s.nil?
       if check_wrath == true


### PR DESCRIPTION
+ Add a new command `!dm request <show|hide>` to bot commands
- Closes Issue #70

Not sure if the db commands will execute correctly. Imitated existing commands with a new table for sever_options