### PR TITLE
Prune comment off displayed request

### DIFF
--- a/dice_maiden_logic.rb
+++ b/dice_maiden_logic.rb
@@ -540,7 +540,9 @@ def build_response
     response = response + " Reason: `#{@comment}`"
   end
   if @request_option
-    response = response + " Request: `[#{@input.strip}]`"
+    # Alias parsed initial request
+    request = @input.split("!")[0]
+    response = response + " Request: `[#{request.strip}]`"
   end
   return response
 end


### PR DESCRIPTION
This now shows the request without the comment in the alias parsed form. E.g:
`!roll +d20 ! Hello` -> `Roll: [16, 8] Result: 16 Reason: Hello Request: [2d20 d1]`