### PR TITLE
Alias for usual DnD stats roll

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ SHARD: 1
 ```
 A single instance of Dice Maiden does not require a sqlite database to operate. Passing the command 'lite' at runtime will tell the bot to ignore any database requirement. 
 
-Example runtime command for a single bot instance: `bundle execute ruby dice_maiden.rb 0 lite`
+Example runtime command for a single bot instance: `bundle exec ruby dice_maiden.rb 0 lite`
 
 ## Single instance Docker install
 
@@ -176,6 +176,8 @@ in most cases. Below is the complete list of aliases , with example rolls, curre
 `sp4` -> `4d10 t8 ie10` Storypath system. The number represents total dice rolled. A d10 system with a target set to 8 and infinite explosion on 10.
 
 `6yz` -> `6d6 t6` Year Zero system. The number represents the total dice rolled. A d6 system with a target set to 6.
+
+`dndstats` -> `6 4d6 k3` Usual DnD stat roll (4d6 drop lowest).
 
 ## Earthdawn System:
 

--- a/dice_maiden_logic.rb
+++ b/dice_maiden_logic.rb
@@ -274,10 +274,12 @@ def log_roll(event)
   @time = Time.now.getutc
   if @roll_set.nil?
     File.open('dice_rolls.log', 'a') do |f|
-      f.puts "#{@time} Shard: #{@shard} |#{@server}| #{@user} Roll: #{@tally} #{@dice_result}"    end
+      f.puts "#{@time} Shard: #{@shard} |#{@server}| #{@user} Roll: #{@tally} #{@dice_result}"
+    end
   else
     File.open('dice_rolls.log', 'a') do |f|
-      f.puts "#{@time} Shard: #{@shard} | #{@server}| #{@user} Rolls:\n #{@roll_set_results}"    end
+      f.puts "#{@time} Shard: #{@shard} | #{@server}| #{@user} Rolls:\n #{@roll_set_results}"
+    end
   end
 end
 

--- a/dice_maiden_logic.rb
+++ b/dice_maiden_logic.rb
@@ -19,7 +19,8 @@ def alias_input_pass(input)
     [/\bsr\d+\b/i, 'Shadowrun', /\bsr(\d+)\b/i, '\\1d6 t5'], # Shadowrun system
     [/\b\d+d%\B/i, 'Percentile roll', /\b(\d+)d%\B/i, '\\1d100'], # Roll a d100
     [/\bsp\d+\b/i, 'Storypath', /\bsp(\d+)\b/i, 'ul \\1d10 ie10 t8'], # storypath system
-    [/\b\d+yz\b/i, 'Year Zero', /\b(\d+)yz\b/i, '\\1d6 t6'] # year zero system
+    [/\b\d+yz\b/i, 'Year Zero', /\b(\d+)yz\b/i, '\\1d6 t6'], # year zero system
+    [/\bdndstats\b/i, "DnD Stat-roll", /\b(dndstats)\b/i, '6 4d6 k3'] # DnD character stats - 4d6 drop lowest 6 times
   ]
 
   @alias_types = []
@@ -273,12 +274,10 @@ def log_roll(event)
   @time = Time.now.getutc
   if @roll_set.nil?
     File.open('dice_rolls.log', 'a') do |f|
-      f.puts "#{@time} Shard: #{@shard} |#{@server}| #{@user} Roll: #{@tally} #{@dice_result}"
-    end
+      f.puts "#{@time} Shard: #{@shard} |#{@server}| #{@user} Roll: #{@tally} #{@dice_result}"    end
   else
     File.open('dice_rolls.log', 'a') do |f|
-      f.puts "#{@time} Shard: #{@shard} | #{@server}| #{@user} Rolls:\n #{@roll_set_results}"
-    end
+      f.puts "#{@time} Shard: #{@shard} | #{@server}| #{@user} Rolls:\n #{@roll_set_results}"    end
   end
 end
 


### PR DESCRIPTION
I created an alias requested in #128 (so `!roll dndstats` will result in `!roll 6 4d6 k3` - 4d6 drop lowest for all 6 stats).