### PR TITLE
add support for godbound's damage chart

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -94,6 +94,7 @@ Style/FrozenStringLiteralComment:
     - 'dice_maiden_logic.rb'
     - 'earthdawn_logic.rb'
     - 'scripts/dice_maiden_quota.rb'
+    - 'godbound_logic.rb'
 
 # Offense count: 13
 # Configuration parameters: AllowedVariables.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ Dark Heresy 2nd edition syntaxes:
 
 `!roll dh 4d10` : Roll four ten-sided dice for dark heresy 2nd edition. If your roll contains a natural 10, you will be prompted with a righteous fury notification!
 
+Godbound damage roll example syntax: 
+
+`!roll gb 1d12+4` : Roll 1d12, add 4, then compare against the game's damage chart
+
+`!roll gb 8d8` : Roll 8d8, compare each die against the game's damage chart, and then sum
+
 ## Alias Rolls
 Alias rolls are commands that are shorthand for a longer, more complex comand. They can also change what the dice faces appear as
 in most cases. Below is the complete list of aliases , with example rolls, currently supported by Dice Maiden. Have a game system that you want turned into an alias? Create an issue on github to get it added to this list!

--- a/dice_maiden.rb
+++ b/dice_maiden.rb
@@ -54,6 +54,7 @@ mutex = Mutex.new
     @simple_output = false
     @wng = false
     @dh = false
+    @godbound = false
     @do_tally_shuffle = false
     @ed = false
 

--- a/godbound_logic.rb
+++ b/godbound_logic.rb
@@ -1,0 +1,18 @@
+def godbound_damage_total(results)
+  results.reduce(0) do |sum, n|
+    sum + godbound_damage_conversion(n)
+  end
+end
+
+def godbound_damage_conversion(raw_number)
+  case [raw_number, 10].min
+  when 10
+    4
+  when 6..9
+    2
+  when 2..5
+    1
+  when 1
+    0
+  end
+end


### PR DESCRIPTION
Adds support for rolling damage against Godbound's damage chart

![image](https://user-images.githubusercontent.com/17840614/170363652-289a490a-846a-4426-93c2-d2397d507309.png)
