### PR TITLE
aliases for Chronicles of Darkness

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Dark Heresy 2nd edition syntaxes:
 Alias rolls are commands that are shorthand for a longer, more complex comand. They can also change what the dice faces appear as
 in most cases. Below is the complete list of aliases , with example rolls, currently supported by Dice Maiden. Have a game system that you want turned into an alias? Create an issue on github to get it added to this list!
 
-`4cod` -> `4d10 t8 ie10` Chronicles of Darkness. The first number is the number of dice to roll.
+`4cod` -> `4d10 t8 ie10` Chronicles of Darkness. The first number is the number of dice to roll (use cod8, cod9 and codr for 8-again, 9-again and rote quality rolls).
 
 `4wod8` -> `4d10 f1 ie10 t8` World of darkness 4th edition. The first number is the number of dice to roll and the second is the toughness of the check.
 

--- a/dice_maiden_logic.rb
+++ b/dice_maiden_logic.rb
@@ -14,10 +14,10 @@ def alias_input_pass(input)
     [/\B-d\d+\b/i, 'Disadvantage', /\B-d(\d+)\b/i, '2d\\1 kl1'], # Roll two dice of the specified size and keep the lowest
     [/\B\+d%\B/i, 'Advantage on percentile', /\B\+d%\B/i, '((2d10kl1-1) *10) + 1d10'], # Roll two d10s for the tens column and keep the lowest (roll under system) then add a d10 for the ones
     [/\B-d%\B/i, 'Disadvantage on percentile', /\B-d%\B/i, '((2d10k1-1) *10) + 1d10'], # Roll two d10s for the tens column and keep the highest (roll under system) then add a d10 for the ones
-    [/\b\d+CoD\b/i, 'CoD', /\b(\d+)CoD\b/i, '\\1d10 ie10 t8'], # Chronicles of Darkness (default, 10-again)
-    [/\b\d+CoD\b/i, 'CoD8', /\b(\d+)CoD\b/i, '\\1d10 ie9 t8'], # Chronicles of Darkness (8-again)
-    [/\b\d+CoD\b/i, 'CoD9', /\b(\d+)CoD\b/i, '\\1d10 ie8 t8'], # Chronicles of Darkness (9-again)
-    [/\b\d+CoD\b/i, 'CoDR', /\b(\d+)CoD\b/i, '\\1d10 r7 t8'], # Chronicles of Darkness (Rote quality, reroll all failed)
+    [/\b\d+CoD\b/i, 'CoD 10-again', /\b(\d+)CoD\b/i, '\\1d10 ie10 t8'], # Chronicles of Darkness (default, 10-again)
+    [/\b\d+CoD8\b/i, 'CoD 8-again', /\b(\d+)CoD8\b/i, '\\1d10 ie9 t8'], # Chronicles of Darkness (8-again)
+    [/\b\d+CoD9\b/i, 'CoD 9-again', /\b(\d+)CoD9\b/i, '\\1d10 ie8 t8'], # Chronicles of Darkness (9-again)
+    [/\b\d+CoDR\b/i, 'CoD rote quality', /\b(\d+)CoDR\b/i, '\\1d10 r7 t8'], # Chronicles of Darkness (Rote quality, reroll all failed)
     [/\bd6s\d+\b/i, 'The D6 System', /\bd6s(\d+)\b/i, '\\1d6 + 1d6 ie'], # The D6 System
     [/\bsr\d+\b/i, 'Shadowrun', /\bsr(\d+)\b/i, '\\1d6 t5'], # Shadowrun system
     [/\b\d+d%\B/i, 'Percentile roll', /\b(\d+)d%\B/i, '\\1d100'], # Roll a d100

--- a/dice_maiden_logic.rb
+++ b/dice_maiden_logic.rb
@@ -14,7 +14,10 @@ def alias_input_pass(input)
     [/\B-d\d+\b/i, 'Disadvantage', /\B-d(\d+)\b/i, '2d\\1 kl1'], # Roll two dice of the specified size and keep the lowest
     [/\B\+d%\B/i, 'Advantage on percentile', /\B\+d%\B/i, '((2d10kl1-1) *10) + 1d10'], # Roll two d10s for the tens column and keep the lowest (roll under system) then add a d10 for the ones
     [/\B-d%\B/i, 'Disadvantage on percentile', /\B-d%\B/i, '((2d10k1-1) *10) + 1d10'], # Roll two d10s for the tens column and keep the highest (roll under system) then add a d10 for the ones
-    [/\b\d+CoD\b/i, 'CoD', /\b(\d+)CoD\b/i, '\\1d10 ie10 t8'], # Chronicles of Darkness
+    [/\b\d+CoD\b/i, 'CoD', /\b(\d+)CoD\b/i, '\\1d10 ie10 t8'], # Chronicles of Darkness (default, 10-again)
+    [/\b\d+CoD\b/i, 'CoD8', /\b(\d+)CoD\b/i, '\\1d10 ie9 t8'], # Chronicles of Darkness (8-again)
+    [/\b\d+CoD\b/i, 'CoD9', /\b(\d+)CoD\b/i, '\\1d10 ie8 t8'], # Chronicles of Darkness (9-again)
+    [/\b\d+CoD\b/i, 'CoDR', /\b(\d+)CoD\b/i, '\\1d10 ie8 r7'], # Chronicles of Darkness (Rote quality, reroll all failed)
     [/\bd6s\d+\b/i, 'The D6 System', /\bd6s(\d+)\b/i, '\\1d6 + 1d6 ie'], # The D6 System
     [/\bsr\d+\b/i, 'Shadowrun', /\bsr(\d+)\b/i, '\\1d6 t5'], # Shadowrun system
     [/\b\d+d%\B/i, 'Percentile roll', /\b(\d+)d%\B/i, '\\1d100'], # Roll a d100

--- a/dice_maiden_logic.rb
+++ b/dice_maiden_logic.rb
@@ -17,7 +17,7 @@ def alias_input_pass(input)
     [/\b\d+CoD\b/i, 'CoD', /\b(\d+)CoD\b/i, '\\1d10 ie10 t8'], # Chronicles of Darkness (default, 10-again)
     [/\b\d+CoD\b/i, 'CoD8', /\b(\d+)CoD\b/i, '\\1d10 ie9 t8'], # Chronicles of Darkness (8-again)
     [/\b\d+CoD\b/i, 'CoD9', /\b(\d+)CoD\b/i, '\\1d10 ie8 t8'], # Chronicles of Darkness (9-again)
-    [/\b\d+CoD\b/i, 'CoDR', /\b(\d+)CoD\b/i, '\\1d10 ie8 r7'], # Chronicles of Darkness (Rote quality, reroll all failed)
+    [/\b\d+CoD\b/i, 'CoDR', /\b(\d+)CoD\b/i, '\\1d10 r7 t8'], # Chronicles of Darkness (Rote quality, reroll all failed)
     [/\bd6s\d+\b/i, 'The D6 System', /\bd6s(\d+)\b/i, '\\1d6 + 1d6 ie'], # The D6 System
     [/\bsr\d+\b/i, 'Shadowrun', /\bsr(\d+)\b/i, '\\1d6 t5'], # Shadowrun system
     [/\b\d+d%\B/i, 'Percentile roll', /\b(\d+)d%\B/i, '\\1d100'], # Roll a d100


### PR DESCRIPTION
Adds aliases for 8-again, 9-again and rote quality rolls often used in Chronicles of darkness.
I should say this is the first time I wrote anything in Ruby, so please check that there are no mistakes in my code 🙏 

Based on this issue: https://github.com/Humblemonk/DiceMaiden/issues/200