### PR TITLE
Return Alias Request in Output

### DIFF
--- a/dice_maiden.rb
+++ b/dice_maiden.rb
@@ -59,6 +59,10 @@ inc_cmd = lambda do |event|
     # next if input_valid(event) == false
     # check_request_option(event)
 
+    # check for comment
+    check_comment
+    @roll_request = @event_roll.dup
+
     @input = alias_input_pass(@event_roll) # Do alias pass as soon as we get the message
     @simple_output = false
     @wng = false
@@ -78,7 +82,6 @@ inc_cmd = lambda do |event|
 
     @roll = @input
     @check = @prefix + @roll
-    @comment = ''
     @test_status = ''
     # check user
     check_user_or_nick(event) unless event.channel.pm?
@@ -87,8 +90,6 @@ inc_cmd = lambda do |event|
       event.respond(content: "#{@user} roll is empty! Please type a complete dice roll message")
       next
     end
-    # check for comment
-    check_comment
     # check for modifiers that should apply to everything
     check_universal_modifiers
 
@@ -127,9 +128,8 @@ inc_cmd = lambda do |event|
         next if error_encountered
 
         log_roll(event) if @launch_option == 'debug'
-        get_request
         if @comment.to_s.empty? || @comment.to_s.nil?
-          event.respond(content: "#{@user} Request: `[#{@request.strip}]` Rolls:\n#{@roll_set_results}")
+          event.respond(content: "#{@user} Request: `[#{@roll_request.strip}]` Rolls:\n#{@roll_set_results}")
         else
           event.respond(content: "#{@user} Rolls:\n#{@roll_set_results} Reason: `#{@comment}`")
         end

--- a/dice_maiden_logic.rb
+++ b/dice_maiden_logic.rb
@@ -68,14 +68,15 @@ def check_user_or_nick(event)
 end
 
 def check_comment
-  if @input.include?('!')
-    @comment = @input.partition('!').last.lstrip
+  @comment = ''
+  if @event_roll.include?('!')
+    @comment = @event_roll.partition('!').last.lstrip
     # remove @ user ids from comments to prevent abuse
     @comment.gsub!(/<@!\d+>/, '')
     @do_tally_shuffle = true if @comment.include? 'unsort'
-    @roll = @input[/(^.*)!/]
-    @roll.slice! @comment
-    @roll.slice! '!'
+    @event_roll = @event_roll[/(^.*)!/]
+    @event_roll.slice! @comment
+    @event_roll.slice! '!'
   end
 end
 
@@ -680,14 +681,8 @@ def roll_sets_valid(event)
   end
 end
 
-def get_request
-  # Alias parsed initial request
-  @request = @input.split('!')[0]
-end
-
 def build_response
-  get_request
-  response = "#{@user} Request: `[#{@request.strip}]`"
+  response = "#{@user} Request: `[#{@roll_request.strip}]`"
   unless @simple_output
     response += " Roll: `#{@tally}`"
     response += " Rerolls: `#{@reroll_count}`" if @show_rerolls


### PR DESCRIPTION
Remove the comment from the input initially and then preserve the user request string before parsing aliases.

Then in the output use the initial request string rather than the parsed roll string.

This should make it easier for users to tell what they rolled in a meaningful way. The parsed roll string does not always relate clearly to the alias.